### PR TITLE
Slf4j over apache logging

### DIFF
--- a/quickfixj-spring-boot-starter/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/ConnectorManager.java
+++ b/quickfixj-spring-boot-starter/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/ConnectorManager.java
@@ -17,8 +17,7 @@
 package io.allune.quickfixj.spring.boot.starter.connection;
 
 import io.allune.quickfixj.spring.boot.starter.exception.ConfigurationException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.util.Assert;
 import quickfix.ConfigError;
@@ -31,9 +30,8 @@ import quickfix.RuntimeError;
  *
  * @author Eduardo Sanchez-Ros
  */
+@Slf4j
 public class ConnectorManager implements SmartLifecycle {
-
-    private final Log logger = LogFactory.getLog(getClass());
 
     private final Connector connector;
 
@@ -89,9 +87,7 @@ public class ConnectorManager implements SmartLifecycle {
     public void start() {
         synchronized (this.lifecycleMonitor) {
             if (!isRunning()) {
-                if (logger.isInfoEnabled()) {
-                    logger.info("start: Starting ConnectorManager");
-                }
+                log.info("start: Starting ConnectorManager");
                 try {
                     connector.start();
                 } catch (ConfigError | RuntimeError ex) {
@@ -113,9 +109,7 @@ public class ConnectorManager implements SmartLifecycle {
     public void stop() {
         synchronized (this.lifecycleMonitor) {
             if (isRunning()) {
-                if (logger.isInfoEnabled()) {
-                    logger.info("stop: Stopping ConnectorManager");
-                }
+                log.info("stop: Stopping ConnectorManager");
                 try {
                     connector.stop();
                 } finally {

--- a/quickfixj-spring-boot-starter/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/SessionSettingsLocator.java
+++ b/quickfixj-spring-boot-starter/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/SessionSettingsLocator.java
@@ -17,8 +17,7 @@
 package io.allune.quickfixj.spring.boot.starter.connection;
 
 import io.allune.quickfixj.spring.boot.starter.exception.SettingsNotFoundException;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -34,9 +33,8 @@ import static java.lang.Thread.currentThread;
  *
  * @author Eduardo Sanchez-Ros
  */
+@Slf4j
 public class SessionSettingsLocator {
-
-    private static final Log logger = LogFactory.getLog(SessionSettingsLocator.class);
 
     private SessionSettingsLocator() {
         //
@@ -70,7 +68,7 @@ public class SessionSettingsLocator {
         if (applicationConfigLocation != null) {
             resource = loadResource(applicationConfigLocation);
             if (resource != null && resource.exists()) {
-                logger.info("Loading settings from application property '" + applicationConfigLocation + "'");
+                log.info("Loading settings from application property '{}'", applicationConfigLocation);
                 return new SessionSettings(resource.getInputStream());
             }
         }
@@ -84,7 +82,7 @@ public class SessionSettingsLocator {
             if (configSystemProperty != null) {
                 Resource resource = loadResource(configSystemProperty);
                 if (resource != null && resource.exists()) {
-                    logger.info("Loading settings from System property '" + systemProperty + "'");
+                    log.info("Loading settings from System property '{}'", systemProperty);
                     return new SessionSettings(resource.getInputStream());
                 }
             }
@@ -97,7 +95,7 @@ public class SessionSettingsLocator {
         if (fileSystemLocation != null) {
             Resource resource = loadResource(fileSystemLocation);
             if (resource != null && resource.exists()) {
-                logger.info("Loading settings from default filesystem location '" + fileSystemLocation + "'");
+                log.info("Loading settings from default filesystem location '{}'", fileSystemLocation);
                 return new SessionSettings(resource.getInputStream());
             }
         }
@@ -109,7 +107,7 @@ public class SessionSettingsLocator {
         if (classpathLocation != null) {
             Resource resource = loadResource(classpathLocation);
             if (resource != null && resource.exists()) {
-                logger.info("Loading settings from default classpath location '" + classpathLocation + "'");
+                log.info("Loading settings from default classpath location '{}'", classpathLocation);
                 return new SessionSettings(resource.getInputStream());
             }
         }


### PR DESCRIPTION
As stated in https://github.com/esanchezros/quickfixj-spring-boot-starter/issues/7

Also avoids some string concatenations and log enabled checks since slf4j already takes care of it.