### PR TITLE
Remove mockito from main dependencies

### DIFF
--- a/quickfixj-spring-boot-actuator/pom.xml
+++ b/quickfixj-spring-boot-actuator/pom.xml
@@ -70,6 +70,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
 Just saw that the mockito dependency is not under the test scope.
 Sorry for the late (and small) PR.