### PR TITLE
Add threaded initiator and acceptor autoconfiguration

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,7 @@ your project.
 <dependency>
 	<groupId>io.allune</groupId>
 	<artifactId>quickfixj-spring-boot-starter</artifactId>
-	<version>2.1.0</version>
+	<version>2.1.1</version>
 </dependency>
 ----
 
@@ -39,7 +39,7 @@ To enable the actuator endpoints you will also have to add the QuickFixJ Spring 
 <dependency>
     <groupId>io.allune</groupId>
     <artifactId>quickfixj-spring-boot-actuator</artifactId>
-	<version>2.1.0</version>
+	<version>2.1.1</version>
 </dependency>
 ----
 
@@ -85,6 +85,7 @@ quickfixj.server.config=classpath:quickfixj-server.cfg # location of the quickfi
 quickfixj.server.auto-startup=true # whether to auto-connect to the remote endpoint at start up
 quickfixj.server.phase=0 # phase in which this connection manager should be started and stopped
 quickfixj.server.jmx-enabled=true # whether to register the jmx mbeans for the acceptor
+quickfixj.server.concurrent.enabled=true # whether to use a simple SocketAcceptor or a ThreadedSocketAcceptor
 ----
 
 ==== QuickFixJ Server Actuator properties
@@ -180,6 +181,7 @@ quickfixj.client.config=classpath:quickfixj-client.cfg # location of the quickfi
 quickfixj.client.auto-startup=true # whether to auto-connect to the remote endpoint at start up
 quickfixj.client.phase=0 # phase in which this connection manager should be started and stopped
 quickfixj.client.jmx-enabled=true # whether to register the jmx mbeans for the initiator
+quickfixj.client.concurrent.enabled=true # whether to use a simple SocketInitiator or a ThreadedSocketInitiator
 ----
 
 ==== QuickFixJ Client Actuator properties

--- a/quickfixj-spring-boot-starter/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/client/QuickFixJClientAutoConfiguration.java
+++ b/quickfixj-spring-boot-starter/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/client/QuickFixJClientAutoConfiguration.java
@@ -32,18 +32,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import quickfix.Application;
-import quickfix.ApplicationAdapter;
-import quickfix.ConfigError;
-import quickfix.DefaultMessageFactory;
-import quickfix.Initiator;
-import quickfix.LogFactory;
-import quickfix.MemoryStoreFactory;
-import quickfix.MessageFactory;
-import quickfix.MessageStoreFactory;
-import quickfix.ScreenLogFactory;
-import quickfix.SessionSettings;
-import quickfix.SocketInitiator;
+import quickfix.*;
 
 import javax.management.JMException;
 import javax.management.ObjectName;
@@ -99,11 +88,25 @@ public class QuickFixJClientAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(name = "clientInitiator")
+    @ConditionalOnProperty(prefix = "quickfixj.client.concurrent", name = "enabled", havingValue = "false", matchIfMissing = true)
     public Initiator clientInitiator(Application clientApplication, MessageStoreFactory clientMessageStoreFactory,
                                      SessionSettings clientSessionSettings, LogFactory clientLogFactory,
                                      MessageFactory clientMessageFactory) throws ConfigError {
 
         return new SocketInitiator(clientApplication, clientMessageStoreFactory, clientSessionSettings,
+                clientLogFactory, clientMessageFactory);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = "clientInitiator")
+    @ConditionalOnProperty(prefix = "quickfixj.client.concurrent", name = "enabled", havingValue = "true")
+    public Initiator clientThreadedInitiator(Application clientApplication,
+                                           MessageStoreFactory clientMessageStoreFactory,
+                                           SessionSettings clientSessionSettings,
+                                           LogFactory clientLogFactory,
+                                           MessageFactory clientMessageFactory) throws ConfigError {
+
+        return new ThreadedSocketInitiator(clientApplication, clientMessageStoreFactory, clientSessionSettings,
                 clientLogFactory, clientMessageFactory);
     }
 


### PR DESCRIPTION
Add support for auto-configuration threaded initiator/acceptor.

I know it is not directly related to the already shared todo list but it's a simple and drop-in implementation.

ps: is there a reason to use conditional beans by name and not by type ?

Thank you!!