### PR TITLE
add NestedConfigurationProperty annotations to QuickFixJBootProperties

### DIFF
--- a/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/QuickFixJBootProperties.java
+++ b/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/QuickFixJBootProperties.java
@@ -17,6 +17,7 @@ package io.allune.quickfixj.spring.boot.starter.autoconfigure;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Holds all the relevant starter properties which can be configured with
@@ -30,7 +31,9 @@ public class QuickFixJBootProperties {
 
 	public static final String PROPERTY_PREFIX = "quickfixj";
 
+	@NestedConfigurationProperty
 	private ConnectorConfig client = new ConnectorConfig();
 
+	@NestedConfigurationProperty
 	private ConnectorConfig server = new ConnectorConfig();
 }


### PR DESCRIPTION
In IDE, we see quickfixJ properties as non existant :

![Greenshot 2025-02-19 08 27 00](https://github.com/user-attachments/assets/0307e1e2-d366-4db8-97b1-175d070ceb0c)

With this modification IDE Help will work again.