### PR TITLE
Add option to resolve placeholders in configuration files

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -209,7 +209,7 @@ to configure the FIX sessions. The configuration is resolved using the following
 
 |quickfixj.server.resolve-placeholders
 |true
-|Whether to resolve `${...}` placeholders against the Spring Environment. This *only* works with the configuration file configured in `quickfixj.server.config`. (default: `false`)
+|Whether to resolve `${...}` placeholders against the Spring Environment. This *only* works when used with `quickfixj.server.config`. (default: `false`)
 
 |quickfixj.server.config
 |classpath:quickfixj-server.cfg
@@ -704,7 +704,7 @@ to configure the FIX sessions. The configuration is resolved using the following
 
 |quickfixj.client.resolve-placeholders
 |true
-|Whether to resolve `${...}` placeholders against the Spring Environment. This *only* works with the configuration file configured in `quickfixj.client.config`. (default: `false`)
+|Whether to resolve `${...}` placeholders against the Spring Environment. This *only* works when used with `quickfixj.client.config`. (default: `false`)
 
 |quickfixj.client.config
 |classpath:quickfixj-client.cfg

--- a/README.adoc
+++ b/README.adoc
@@ -207,6 +207,10 @@ to configure the FIX sessions. The configuration is resolved using the following
 |true
 |Whether the QuickFix/J Server is enabled.
 
+|quickfixj.server.resolve-placeholders
+|true
+|Whether to resolve `${...}` placeholders against the Spring Environment. This *only* works with the configuration file configured in `quickfixj.server.config`. (default: `false`)
+
 |quickfixj.server.config
 |classpath:quickfixj-server.cfg
 |Location of the QuickFix/J configuration file.
@@ -289,6 +293,7 @@ For example:
 [source,properties]
 ----
 quickfixj.server.enabled=true
+quickfixj.server.resolve-placeholders=true
 quickfixj.server.config=classpath:quickfixj-server.cfg
 quickfixj.server.configString=[default]  \r\n\... (see below for an example)
 quickfixj.server.auto-startup=true
@@ -316,6 +321,7 @@ quickfixj.server.concurrent.threadNamePrefix="QuickFixJ Spring Boot Starter thre
 quickfixj:
   server:
     enabled: true
+    resolve-placeholders: true
     config: classpath:quickfixj-server.cfg
     auto-startup: true
     force-disconnect: false
@@ -363,6 +369,44 @@ BeginString=FIX.4.4
 SenderCompID=EXECUTOR
 TargetCompID=*
 SocketAcceptPort=9876
+AcceptorTemplate=Y
+----
+
+=== QuickFIX/J Server placeholder resolution
+When using `quickfixj.server.config` placeholder resolution can be enabled using the `quickfixj.server.resolve-placeholders` property. See Spring Boot's https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.files.property-placeholders[Property Placeholder] documentation for further information.
+
+[source,properties]
+----
+quickfixj.client.resolve-placeholders=true
+quickfixj.client.config=classpath:quickfixj-client.cfg
+fix.sender-comp-id=EXECUTOR
+fix.target-comp-id=*
+----
+
+[source,yml]
+----
+quickfixj:
+  client:
+    resolve-placeholders: true
+    config: classpath:quickfixj-client.cfg
+fix:
+  sender-comp-id: EXECUTOR
+  target-comp-id: *
+----
+
+[source,ini]
+----
+[default]
+ConnectionType=acceptor
+StartTime=00:00:00
+EndTime=00:00:00
+HeartBtInt=30
+
+[session]
+BeginString=FIX.4.4
+SenderCompID=${FIX_SENDERCOMPID}
+TargetCompID=${FIX_TARGETCOMPID}
+SocketAcceptPort=${FIX_SOCKETACCEPTPORT:9876}
 AcceptorTemplate=Y
 ----
 
@@ -658,6 +702,10 @@ to configure the FIX sessions. The configuration is resolved using the following
 |true
 |Whether the QuickFix/J Client is enabled.
 
+|quickfixj.client.resolve-placeholders
+|true
+|Whether to resolve `${...}` placeholders against the Spring Environment. This *only* works with the configuration file configured in `quickfixj.client.config`. (default: `false`)
+
 |quickfixj.client.config
 |classpath:quickfixj-client.cfg
 |Location of the QuickFix/J configuration file.
@@ -736,6 +784,7 @@ For example:
 [source,properties]
 ----
 quickfixj.client.enabled=true
+quickfixj.client.resolve-placeholders=true
 quickfixj.client.config=classpath:quickfixj-client.cfg
 quickfixj.client.configString=[default]  \r\n\... (see below for an example)
 quickfixj.client.auto-startup=true
@@ -761,6 +810,7 @@ quickfixj.client.concurrent.threadNamePrefix="QuickFixJ Spring Boot Starter thre
 quickfixj:
   client:
     enabled: true
+    resolve-placeholders: true
     config: classpath:quickfixj-client.cfg
     auto-startup: true
     force-disconnect: false
@@ -779,6 +829,41 @@ quickfixj:
       threadNamePrefix: "QuickFixJ Spring Boot Starter thread-"
     message-store-factory: memory
     log-factory: screen
+----
+
+=== QuickFIX/J Client placeholder resolution
+When using `quickfixj.client.config` placeholder resolution can be enabled using the `quickfixj.client.resolve-placeholders` property. See Spring Boot's https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.files.property-placeholders[Property Placeholder] documentation for further information.
+
+[source,properties]
+----
+quickfixj.client.resolve-placeholders=true
+quickfixj.client.config=classpath:quickfixj-client.cfg
+fix.sender-comp-id=EXEC
+fix.target-comp-id=BANZI
+fix.host=localhost
+----
+
+[source,yml]
+----
+quickfixj:
+  client:
+    resolve-placeholders: true
+    config: classpath:quickfixj-client.cfg
+fix:
+  sender-comp-id: EXEC
+  target-comp-id: BANZI
+  host: localhost
+----
+
+[source,ini]
+----
+[SESSION]
+BeginString=FIX.4.4
+SessionQualifier=Example
+SenderCompID=${FIX_SENDERCOMPID}
+TargetCompID=${FIX_TARGETCOMPID}
+SocketConnectHost=${FIX_HOST}
+SocketConnectPort=${FIX_PORT:9876}
 ----
 
 === QuickFIX/J configuration file in properties and yaml files

--- a/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/ConnectorConfig.java
+++ b/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/ConnectorConfig.java
@@ -48,6 +48,11 @@ public class ConnectorConfig {
 	private String config;
 
 	/**
+	 * Allow resolving placeholders if a configuration file is used.
+	 */
+	private boolean resolvePlaceholders = false;
+
+	/**
 	 * The configuration string to use to initialize QuickFIX/J client/server.
 	 */
 	private String configString;

--- a/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/ConnectorConfig.java
+++ b/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/ConnectorConfig.java
@@ -16,6 +16,7 @@
 package io.allune.quickfixj.spring.boot.starter.autoconfigure;
 
 import io.allune.quickfixj.spring.boot.starter.connection.ConnectorManager;
+import io.allune.quickfixj.spring.boot.starter.connection.SessionSettingsLocator;
 import lombok.Data;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
@@ -48,7 +49,12 @@ public class ConnectorConfig {
 	private String config;
 
 	/**
-	 * Allow resolving placeholders if a configuration file is used.
+	 * Whether to resolve {@code ${...}} placeholders against the Spring {@link org.springframework.core.env.Environment}
+	 * when loading the configuration from {@link #config the configuration file}. Unresolvable placeholders cause
+	 * startup to fail. This flag has no effect on {@link #configString}, since values bound from
+	 * {@code application.yml}/properties are already resolved during property binding.
+	 *
+	 * @see SessionSettingsLocator#loadSettings(String...)
 	 */
 	private boolean resolvePlaceholders = false;
 

--- a/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/client/QuickFixJClientAutoConfiguration.java
+++ b/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/client/QuickFixJClientAutoConfiguration.java
@@ -18,6 +18,7 @@ package io.allune.quickfixj.spring.boot.starter.autoconfigure.client;
 import io.allune.quickfixj.spring.boot.starter.application.EventPublisherApplicationAdapter;
 import io.allune.quickfixj.spring.boot.starter.autoconfigure.QuickFixJBootProperties;
 import io.allune.quickfixj.spring.boot.starter.connection.ConnectorManager;
+import io.allune.quickfixj.spring.boot.starter.connection.ResolvePlaceholderSessionSettingsLocator;
 import io.allune.quickfixj.spring.boot.starter.connection.SessionSettingsLocator;
 import io.allune.quickfixj.spring.boot.starter.exception.ConfigurationException;
 import org.quickfixj.jmx.JmxExporter;
@@ -33,6 +34,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import quickfix.Application;
@@ -503,8 +505,23 @@ public class QuickFixJClientAutoConfiguration {
 	 * @return the client's {@link SessionSettingsLocator}
 	 */
 	@Bean
+	@ConditionalOnProperty(prefix = "quickfixj.client", name = "resolve-placeholders", havingValue = "false", matchIfMissing = true)
 	@ConditionalOnMissingBean
 	public SessionSettingsLocator sessionSettingsLocator(ResourceLoader resourceLoader) {
 		return new SessionSettingsLocator(resourceLoader);
+	}
+
+	/**
+	 * Creates the client's {@link SessionSettingsLocator}
+	 *
+	 * @param resourceLoader The {@link ResourceLoader} to use for loading the properties
+	 * @param environment the configurable environment
+	 * @return the client's {@link SessionSettingsLocator}
+	 */
+	@Bean
+	@ConditionalOnProperty(prefix = "quickfixj.client", name = "resolve-placeholders", havingValue = "true")
+	@ConditionalOnMissingBean
+	public SessionSettingsLocator resolvePlaceholderSessionSettingsLocator(ResourceLoader resourceLoader, ConfigurableEnvironment environment) {
+		return new ResolvePlaceholderSessionSettingsLocator(resourceLoader, environment);
 	}
 }

--- a/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/server/QuickFixJServerAutoConfiguration.java
+++ b/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/server/QuickFixJServerAutoConfiguration.java
@@ -18,6 +18,7 @@ package io.allune.quickfixj.spring.boot.starter.autoconfigure.server;
 import io.allune.quickfixj.spring.boot.starter.application.EventPublisherApplicationAdapter;
 import io.allune.quickfixj.spring.boot.starter.autoconfigure.QuickFixJBootProperties;
 import io.allune.quickfixj.spring.boot.starter.connection.ConnectorManager;
+import io.allune.quickfixj.spring.boot.starter.connection.ResolvePlaceholderSessionSettingsLocator;
 import io.allune.quickfixj.spring.boot.starter.connection.SessionSettingsLocator;
 import io.allune.quickfixj.spring.boot.starter.exception.ConfigurationException;
 import org.quickfixj.jmx.JmxExporter;
@@ -33,6 +34,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import quickfix.Acceptor;
@@ -530,8 +532,23 @@ public class QuickFixJServerAutoConfiguration {
 	 * @return the server's {@link SessionSettingsLocator}
 	 */
 	@Bean
+	@ConditionalOnProperty(prefix = "quickfixj.server", name = "resolve-placeholders", havingValue = "false", matchIfMissing = true)
 	@ConditionalOnMissingBean
 	public SessionSettingsLocator sessionSettingsLocator(ResourceLoader resourceLoader) {
 		return new SessionSettingsLocator(resourceLoader);
+	}
+
+	/**
+	 * Creates the client's {@link SessionSettingsLocator}
+	 *
+	 * @param resourceLoader The {@link ResourceLoader} to use for loading the properties
+	 * @param environment the configurable environment
+	 * @return the client's {@link SessionSettingsLocator}
+	 */
+	@Bean
+	@ConditionalOnProperty(prefix = "quickfixj.server", name = "resolve-placeholders", havingValue = "true")
+	@ConditionalOnMissingBean
+	public SessionSettingsLocator resolvePlaceholderSessionSettingsLocator(ResourceLoader resourceLoader, ConfigurableEnvironment environment) {
+		return new ResolvePlaceholderSessionSettingsLocator(resourceLoader, environment);
 	}
 }

--- a/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/server/QuickFixJServerAutoConfiguration.java
+++ b/quickfixj-spring-boot-autoconfigure/src/main/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/server/QuickFixJServerAutoConfiguration.java
@@ -539,11 +539,11 @@ public class QuickFixJServerAutoConfiguration {
 	}
 
 	/**
-	 * Creates the client's {@link SessionSettingsLocator}
+	 * Creates the server's {@link SessionSettingsLocator}
 	 *
 	 * @param resourceLoader The {@link ResourceLoader} to use for loading the properties
 	 * @param environment the configurable environment
-	 * @return the client's {@link SessionSettingsLocator}
+	 * @return the server's {@link SessionSettingsLocator}
 	 */
 	@Bean
 	@ConditionalOnProperty(prefix = "quickfixj.server", name = "resolve-placeholders", havingValue = "true")

--- a/quickfixj-spring-boot-autoconfigure/src/test/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/client/QuickFixJClientAutoConfigurationTest.java
+++ b/quickfixj-spring-boot-autoconfigure/src/test/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/client/QuickFixJClientAutoConfigurationTest.java
@@ -18,6 +18,7 @@ package io.allune.quickfixj.spring.boot.starter.autoconfigure.client;
 import io.allune.quickfixj.spring.boot.starter.application.EventPublisherApplicationAdapter;
 import io.allune.quickfixj.spring.boot.starter.autoconfigure.YamlPropertySourceFactory;
 import io.allune.quickfixj.spring.boot.starter.connection.ConnectorManager;
+import io.allune.quickfixj.spring.boot.starter.connection.ResolvePlaceholderSessionSettingsLocator;
 import io.allune.quickfixj.spring.boot.starter.connection.SessionSettingsLocator;
 import io.allune.quickfixj.spring.boot.starter.exception.ConfigurationException;
 import io.allune.quickfixj.spring.boot.starter.template.QuickFixJTemplate;
@@ -361,6 +362,22 @@ public class QuickFixJClientAutoConfigurationTest {
 	}
 
 	@Test
+	public void testAutoConfiguredSessionSettingsLocatorIsDefaultWhenResolvePlaceholdersDisabled() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(SingleThreadedClientInitiatorConfiguration.class);
+		SessionSettingsLocator sessionSettingsLocator = ctx.getBean(SessionSettingsLocator.class);
+		assertThat(sessionSettingsLocator).isExactlyInstanceOf(SessionSettingsLocator.class);
+		ctx.stop();
+	}
+
+	@Test
+	public void testAutoConfiguredSessionSettingsLocatorWhenResolvePlaceholdersEnabled() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(SingleThreadedClientResolvePlaceholdersConfiguration.class);
+		SessionSettingsLocator sessionSettingsLocator = ctx.getBean(SessionSettingsLocator.class);
+		assertThat(sessionSettingsLocator).isInstanceOf(ResolvePlaceholderSessionSettingsLocator.class);
+		ctx.stop();
+	}
+
+	@Test
 	public void testAutoConfiguredBeansClientOverriddenConfiguration() {
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(SingleThreadedClientInitiatorOverrideAllBeansConfiguration.class);
 		assertThatThrownBy(() -> ctx.getBean("clientApplication", Application.class)).isInstanceOf(NoSuchBeanDefinitionException.class);
@@ -441,6 +458,12 @@ public class QuickFixJClientAutoConfigurationTest {
 	@EnableAutoConfiguration
 	@PropertySource("classpath:client-single-threaded/single-threaded-application.properties")
 	static class SingleThreadedClientInitiatorConfiguration {
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@PropertySource("classpath:client-single-threaded/single-threaded-application-resolve-placeholders.properties")
+	static class SingleThreadedClientResolvePlaceholdersConfiguration {
 	}
 
 	@Configuration

--- a/quickfixj-spring-boot-autoconfigure/src/test/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/server/QuickFixJServerAutoConfigurationTest.java
+++ b/quickfixj-spring-boot-autoconfigure/src/test/java/io/allune/quickfixj/spring/boot/starter/autoconfigure/server/QuickFixJServerAutoConfigurationTest.java
@@ -18,6 +18,7 @@ package io.allune.quickfixj.spring.boot.starter.autoconfigure.server;
 import io.allune.quickfixj.spring.boot.starter.application.EventPublisherApplicationAdapter;
 import io.allune.quickfixj.spring.boot.starter.autoconfigure.YamlPropertySourceFactory;
 import io.allune.quickfixj.spring.boot.starter.connection.ConnectorManager;
+import io.allune.quickfixj.spring.boot.starter.connection.ResolvePlaceholderSessionSettingsLocator;
 import io.allune.quickfixj.spring.boot.starter.connection.SessionSettingsLocator;
 import io.allune.quickfixj.spring.boot.starter.exception.ConfigurationException;
 import io.allune.quickfixj.spring.boot.starter.template.QuickFixJTemplate;
@@ -476,6 +477,22 @@ public class QuickFixJServerAutoConfigurationTest {
 	}
 
 	@Test
+	public void testAutoConfiguredSessionSettingsLocatorIsDefaultWhenResolvePlaceholdersDisabled() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(SingleThreadedServerAcceptorConfiguration.class);
+		SessionSettingsLocator sessionSettingsLocator = ctx.getBean(SessionSettingsLocator.class);
+		assertThat(sessionSettingsLocator).isExactlyInstanceOf(SessionSettingsLocator.class);
+		ctx.stop();
+	}
+
+	@Test
+	public void testAutoConfiguredSessionSettingsLocatorWhenResolvePlaceholdersEnabled() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(SingleThreadedServerResolvePlaceholdersConfiguration.class);
+		SessionSettingsLocator sessionSettingsLocator = ctx.getBean(SessionSettingsLocator.class);
+		assertThat(sessionSettingsLocator).isInstanceOf(ResolvePlaceholderSessionSettingsLocator.class);
+		ctx.stop();
+	}
+
+	@Test
 	public void testAutoConfiguredBeansServerOverriddenConfiguration() {
 		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(SingleThreadedServerInitiatorOverrideAllBeansConfiguration.class);
 		assertThatThrownBy(() -> ctx.getBean("serverApplication", Application.class)).isInstanceOf(NoSuchBeanDefinitionException.class);
@@ -567,6 +584,12 @@ public class QuickFixJServerAutoConfigurationTest {
 	@EnableAutoConfiguration
 	@PropertySource("classpath:server-single-threaded/single-threaded-application.properties")
 	static class SingleThreadedServerAcceptorConfiguration {
+	}
+
+	@Configuration
+	@EnableAutoConfiguration
+	@PropertySource("classpath:server-single-threaded/single-threaded-application-resolve-placeholders.properties")
+	static class SingleThreadedServerResolvePlaceholdersConfiguration {
 	}
 
 	private static final class CapturingThreadedSocketAcceptor extends ThreadedSocketAcceptor {

--- a/quickfixj-spring-boot-autoconfigure/src/test/resources/client-single-threaded/single-threaded-application-resolve-placeholders.properties
+++ b/quickfixj-spring-boot-autoconfigure/src/test/resources/client-single-threaded/single-threaded-application-resolve-placeholders.properties
@@ -1,0 +1,7 @@
+quickfixj.client.enabled=true
+quickfixj.client.concurrent.enabled=false
+quickfixj.client.autoStartup=false
+quickfixj.client.config=classpath:quickfixj.cfg
+quickfixj.client.jmx-enabled=true
+quickfixj.client.forceDisconnect=true
+quickfixj.client.resolve-placeholders=true

--- a/quickfixj-spring-boot-autoconfigure/src/test/resources/server-single-threaded/single-threaded-application-resolve-placeholders.properties
+++ b/quickfixj-spring-boot-autoconfigure/src/test/resources/server-single-threaded/single-threaded-application-resolve-placeholders.properties
@@ -1,0 +1,7 @@
+quickfixj.server.enabled=true
+quickfixj.server.concurrent.enabled=false
+quickfixj.server.autoStartup=false
+quickfixj.server.config=classpath:quickfixj.cfg
+quickfixj.server.jmx-enabled=true
+quickfixj.server.forceDisconnect=true
+quickfixj.server.resolve-placeholders=true

--- a/quickfixj-spring-boot-context/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/ResolvePlaceholderSessionSettingsLocator.java
+++ b/quickfixj-spring-boot-context/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/ResolvePlaceholderSessionSettingsLocator.java
@@ -43,11 +43,15 @@ public class ResolvePlaceholderSessionSettingsLocator extends SessionSettingsLoc
 	}
 
 	/**
-     * Reads the resource and resolves any placeholders.
+	 * Reads the resource and resolves any placeholders. Unresolvable placeholders without a default
+	 * value cause an {@link IllegalArgumentException} to be thrown so configuration errors fail fast
+	 * rather than being silently passed through to QuickFIX/J as literal {@code ${...}} values.
+	 *
 	 * @param resource the resource
-     * @return the input stream of the resource with placeholders resolved
+	 * @return the input stream of the resource with placeholders resolved
 	 * @throws IOException if the content stream could not be opened
-	 * @see ConfigurableEnvironment#resolvePlaceholders(String)
+	 * @throws IllegalArgumentException if a placeholder cannot be resolved
+	 * @see ConfigurableEnvironment#resolveRequiredPlaceholders(String)
 	 */
 	@Override
 	public InputStream readResource(Resource resource) throws IOException {
@@ -56,7 +60,7 @@ public class ResolvePlaceholderSessionSettingsLocator extends SessionSettingsLoc
 			StandardCharsets.UTF_8
 		);
 
-		String resolved = environment.resolvePlaceholders(content);
+		String resolved = environment.resolveRequiredPlaceholders(content);
 		return new ByteArrayInputStream(resolved.getBytes(StandardCharsets.UTF_8));
 	}
 }

--- a/quickfixj-spring-boot-context/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/ResolvePlaceholderSessionSettingsLocator.java
+++ b/quickfixj-spring-boot-context/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/ResolvePlaceholderSessionSettingsLocator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.allune.quickfixj.spring.boot.starter.connection;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.StreamUtils;
+import quickfix.SessionSettings;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * {@link SessionSettings} helper class that attempts to load the settings files from the default locations
+ *
+ * @author Richard Jones
+ */
+@Slf4j
+public class ResolvePlaceholderSessionSettingsLocator extends SessionSettingsLocator {
+
+	private final ConfigurableEnvironment environment;
+
+	public ResolvePlaceholderSessionSettingsLocator(ResourceLoader resourceLoader, ConfigurableEnvironment environment) {
+		super(resourceLoader);
+		this.environment = environment;
+	}
+
+	/**
+     * Reads the resource and resolves any placeholders.
+	 * @param resource the resource
+     * @return the input stream of the resource with placeholders resolved
+	 * @throws IOException if the content stream could not be opened
+	 * @see ConfigurableEnvironment#resolvePlaceholders(String)
+	 */
+	@Override
+	public InputStream readResource(Resource resource) throws IOException {
+		String content = StreamUtils.copyToString(
+			resource.getInputStream(),
+			StandardCharsets.UTF_8
+		);
+
+		String resolved = environment.resolvePlaceholders(content);
+		return new ByteArrayInputStream(resolved.getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/quickfixj-spring-boot-context/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/SessionSettingsLocator.java
+++ b/quickfixj-spring-boot-context/src/main/java/io/allune/quickfixj/spring/boot/starter/connection/SessionSettingsLocator.java
@@ -25,6 +25,7 @@ import quickfix.SessionSettings;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
 
 import static java.util.Optional.empty;
@@ -38,7 +39,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 @Slf4j
 public class SessionSettingsLocator {
 
-	private final ResourceLoader resourceLoader;
+	protected final ResourceLoader resourceLoader;
 
 	public SessionSettingsLocator(ResourceLoader resourceLoader) {
 		this.resourceLoader = resourceLoader;
@@ -56,7 +57,7 @@ public class SessionSettingsLocator {
 				Optional<Resource> resource = load(location);
 				if (resource.isPresent()) {
 					log.info("Loading settings from '{}'", location);
-					return new SessionSettings(resource.get().getInputStream());
+					return new SessionSettings(readResource(resource.get()));
 				}
 			}
 
@@ -64,6 +65,16 @@ public class SessionSettingsLocator {
 		} catch (RuntimeException | ConfigError | IOException e) {
 			throw new SettingsNotFoundException(e.getMessage(), e);
 		}
+	}
+
+	/**
+	 * Reads the resource into an {@link InputStream}.
+	 * @param resource the resource
+	 * @return the input stream
+	 * @throws IOException if the content stream could not be opened
+	 */
+	protected InputStream readResource(Resource resource) throws IOException {
+		return resource.getInputStream();
 	}
 
 	public SessionSettings loadSettingsFromString(String configString) {
@@ -77,7 +88,7 @@ public class SessionSettingsLocator {
 		}
 	}
 
-	private Optional<Resource> load(String location) {
+	protected Optional<Resource> load(String location) {
 		if (location == null) {
 			return empty();
 		}

--- a/quickfixj-spring-boot-context/src/test/java/io/allune/quickfixj/spring/boot/starter/connection/ResolvePlaceholderSessionSettingsLocatorTest.java
+++ b/quickfixj-spring-boot-context/src/test/java/io/allune/quickfixj/spring/boot/starter/connection/ResolvePlaceholderSessionSettingsLocatorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.allune.quickfixj.spring.boot.starter.connection;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.DefaultResourceLoader;
+import quickfix.ConfigError;
+import quickfix.SessionSettings;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Richard Jones
+ */
+public class ResolvePlaceholderSessionSettingsLocatorTest {
+
+	@Test
+	void shouldResolveDefaults() throws ConfigError {
+		StandardEnvironment environment = new StandardEnvironment();
+
+		SessionSettingsLocator sessionSettingsLocator = new ResolvePlaceholderSessionSettingsLocator(new DefaultResourceLoader(), environment);
+		SessionSettings settings = sessionSettingsLocator.loadSettings("classpath:quickfixj-placeholders.cfg", null, null, null);
+
+		assertThat("00:00:00").isEqualTo(settings.getString("StartTime"));
+		assertThat("00:00:00").isEqualTo(settings.getString("EndTime"));
+		assertThat("30").isEqualTo(settings.getString("HeartBtInt"));
+		assertThat("5").isEqualTo(settings.getString("ReconnectInterval"));
+
+	}
+
+	@Test
+	void shouldResolvePlaceholders() throws ConfigError {
+		StandardEnvironment environment = new StandardEnvironment();
+		Map<String, Object> props = Map.of(
+			"START_TIME", "00:01:00",
+			"END_TIME", "23:59:00"
+		);
+		environment.getPropertySources().addFirst(
+			new MapPropertySource("test", props)
+		);
+
+		SessionSettingsLocator sessionSettingsLocator = new ResolvePlaceholderSessionSettingsLocator(new DefaultResourceLoader(), environment);
+		SessionSettings settings = sessionSettingsLocator.loadSettings("classpath:quickfixj-placeholders.cfg", null, null, null);
+
+
+		assertThat("00:01:00").isEqualTo(settings.getString("StartTime"));
+		assertThat("23:59:00").isEqualTo(settings.getString("EndTime"));
+		assertThat("30").isEqualTo(settings.getString("HeartBtInt"));
+		assertThat("5").isEqualTo(settings.getString("ReconnectInterval"));
+	}
+}

--- a/quickfixj-spring-boot-context/src/test/java/io/allune/quickfixj/spring/boot/starter/connection/ResolvePlaceholderSessionSettingsLocatorTest.java
+++ b/quickfixj-spring-boot-context/src/test/java/io/allune/quickfixj/spring/boot/starter/connection/ResolvePlaceholderSessionSettingsLocatorTest.java
@@ -15,6 +15,7 @@
  */
 package io.allune.quickfixj.spring.boot.starter.connection;
 
+import io.allune.quickfixj.spring.boot.starter.exception.SettingsNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.env.MapPropertySource;
 import org.springframework.core.env.StandardEnvironment;
@@ -25,6 +26,7 @@ import quickfix.SessionSettings;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * @author Richard Jones
@@ -64,5 +66,17 @@ public class ResolvePlaceholderSessionSettingsLocatorTest {
 		assertThat("23:59:00").isEqualTo(settings.getString("EndTime"));
 		assertThat("30").isEqualTo(settings.getString("HeartBtInt"));
 		assertThat("5").isEqualTo(settings.getString("ReconnectInterval"));
+	}
+
+	@Test
+	void shouldFailWhenPlaceholderCannotBeResolved() {
+		StandardEnvironment environment = new StandardEnvironment();
+
+		SessionSettingsLocator sessionSettingsLocator = new ResolvePlaceholderSessionSettingsLocator(new DefaultResourceLoader(), environment);
+
+		assertThatThrownBy(() -> sessionSettingsLocator.loadSettings("classpath:quickfixj-placeholders-required.cfg", null, null, null))
+			.isInstanceOf(SettingsNotFoundException.class)
+			.hasRootCauseInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("START_TIME");
 	}
 }

--- a/quickfixj-spring-boot-context/src/test/resources/quickfixj-placeholders-required.cfg
+++ b/quickfixj-spring-boot-context/src/test/resources/quickfixj-placeholders-required.cfg
@@ -1,0 +1,5 @@
+[default]
+StartTime=${START_TIME}
+EndTime=${END_TIME}
+HeartBtInt=30
+ReconnectInterval=5

--- a/quickfixj-spring-boot-context/src/test/resources/quickfixj-placeholders.cfg
+++ b/quickfixj-spring-boot-context/src/test/resources/quickfixj-placeholders.cfg
@@ -1,0 +1,5 @@
+[default]
+StartTime=${START_TIME:00:00:00}
+EndTime=${END_TIME:00:00:00}
+HeartBtInt=30
+ReconnectInterval=5


### PR DESCRIPTION
It is often likely that dev/production environments use the same configuration, just different vlaues.

For example, it is likely that `SenderCompID`, `TargetCompID`, `SocketConnectHost`, and `SocketConnectPort` could be different between environments.

This provides an opt-in option to allow resolving custom placeholders in the configuration file.

quickfix.cfg
```
[default]
FileStorePath=target/data/banzai
ConnectionType=initiator
SenderCompID=${SENDER_COMP_ID:BANZAI}
TargetCompID=${TARGET_COMP_ID:EXEC}
SocketConnectHost=${SOCKET_CONNECTION_HOST:localhost}
StartTime=00:00:00
EndTime=00:00:00
HeartBtInt=30
ReconnectInterval=5
FileLogPath=logs-client

[session]
BeginString=FIX.4.0
SocketConnectPort=SocketConnectHost=${SOCKET_CONNECTION_PORT}
```

Placeholder resolution can then be enabled by setting:

* `quickfixj.client.resolve-placeholders=true`
* `quickfixj.server.resolve-placeholders=true`