### PR TITLE
Add spring-boot-configuration-processor annotion processor

### DIFF
--- a/quickfixj-spring-boot-autoconfigure/pom.xml
+++ b/quickfixj-spring-boot-autoconfigure/pom.xml
@@ -117,4 +117,21 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths combine.children="append">
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
Currently there is no `spring-configuration-metadata.json` generated for the `autoconfigure` module (the only one with any `@ConfigurationProperties` annoated classes).

As the project does not use a spring boot parent, this annotaiton processor must be added manually to generate the file.

This can be verified as working with:

```bash
[ -f "quickfixj-spring-boot-autoconfigure/target/classes/META-INF/spring-configuration-metadata.json" ] && echo "File exists" || echo "File does not exist"
```