### PR TITLE
Update README.adoc to match the actual made version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -72,7 +72,7 @@ and add the specific version(s) of the FIX messages you need in your project `de
 
 === Breaking changes with previous versions
 
-==== 4.x.x => 5.0.0
+==== 4.2.x => 4.3.x
 
 There is no API break but the code cannot run with old version of QuickfixJ.
 


### PR DESCRIPTION
@esanchezros I though you will make a v5 considering the breaking change in QuickFixJ version. So here is the documentation fix to match the actual version you made 4.3.0